### PR TITLE
fix: enable Apex One TLS certificate validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2022-2025 Splunk Inc.
+   Copyright (c) 2022-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: Trend Micro Apex One
-Copyright (c) 2022-2025 Splunk Inc.
+Copyright (c) 2022-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Trend Micro Apex One
 
-Publisher: Splunk Community \
-Connector Version: 1.0.3 \
-Product Vendor: Trend Micro \
-Product Name: Apex One \
+Publisher: Splunk Community <br>
+Connector Version: 1.0.3 <br>
+Product Vendor: Trend Micro <br>
+Product Name: Apex One <br>
 Minimum Product Version: 5.3.0
 
 This app provides investigative and containment actions for Trend Micro Apex One
@@ -17,20 +17,21 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **base_url** | required | string | Apex Server URL |
 **application_id** | required | string | Apex Central Application ID |
 **api_key** | required | password | Apex Central API Key |
+**verify_server_cert** | optional | boolean | Verify server certificate |
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[quarantine device](#action-quarantine-device) - Quarantine an endpoint \
-[unquarantine device](#action-unquarantine-device) - Unquarantine an endpoint \
-[list endpoints](#action-list-endpoints) - List all the configured security agents \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[quarantine device](#action-quarantine-device) - Quarantine an endpoint <br>
+[unquarantine device](#action-unquarantine-device) - Unquarantine an endpoint <br>
+[list endpoints](#action-list-endpoints) - List all the configured security agents <br>
 [get system info](#action-get-system-info) - Get information about a security agent
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -45,7 +46,7 @@ No Output
 
 Quarantine an endpoint
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -79,7 +80,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Unquarantine an endpoint
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -113,7 +114,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List all the configured security agents
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -144,7 +145,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get information about a security agent
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -178,7 +179,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/readme.html
+++ b/readme.html
@@ -1,6 +1,6 @@
 <!--
 File: readme.html
-Copyright (c) 2022-2025 Splunk Inc.
+Copyright (c) 2022-2026 Splunk Inc.
 
 Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
 -->

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Enabled TLS server certificate verification by default, with an asset setting for explicitly opting out.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Enabled TLS server certificate verification by default, with an asset setting for explicitly opting out.
+* Enabled TLS server certificate verification by default, with an asset setting for explicitly opting out.

--- a/trendmicroapexone.json
+++ b/trendmicroapexone.json
@@ -10,7 +10,7 @@
     "python_version": "3",
     "product_version_regex": ".*",
     "publisher": "Splunk Community",
-    "license": "Copyright (c) 2022-2025 Splunk Inc.",
+    "license": "Copyright (c) 2022-2026 Splunk Inc.",
     "app_version": "1.0.3",
     "utctime_updated": "2025-04-28T20:36:27.715344Z",
     "package_name": "phantom_trendmicroapexone",
@@ -35,6 +35,12 @@
             "data_type": "password",
             "required": true,
             "order": 2
+        },
+        "verify_server_cert": {
+            "description": "Verify server certificate",
+            "data_type": "boolean",
+            "default": true,
+            "order": 3
         }
     },
     "actions": [
@@ -484,6 +490,18 @@
         }
     ],
     "pip39_dependencies": {
+        "wheel": [
+            {
+                "module": "PyJWT",
+                "input_file": "wheels/py3/PyJWT-2.4.0-py3-none-any.whl"
+            },
+            {
+                "module": "chardet",
+                "input_file": "wheels/shared/chardet-3.0.4-py2.py3-none-any.whl"
+            }
+        ]
+    },
+    "pip313_dependencies": {
         "wheel": [
             {
                 "module": "PyJWT",

--- a/trendmicroapexone_connector.py
+++ b/trendmicroapexone_connector.py
@@ -1,6 +1,6 @@
 # File: trendmicroapexone_connector.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -221,7 +221,7 @@ class TrendMicroApexOneConnector(BaseConnector):
         try:
             r = request_func(
                 url,
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
                 headers=headers,
                 **kwargs,
             )

--- a/trendmicroapexone_consts.py
+++ b/trendmicroapexone_consts.py
@@ -1,6 +1,6 @@
 # File: trendmicroapexone_consts.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Enables TLS server certificate validation by default for all Apex One API calls.
- Adds the optional Verify server certificate asset setting for explicit opt-out in self-signed or private-CA deployments.
- Includes v2.2.4 package-generated Python 3.13 dependency metadata and canonical documentation output.

## Tracking

- PAPP: PAPP-38091
- PSAAS: PSAAS-30959
- Provenance: VULN-93684, FS-1787

## Validation

- Full all-files pre-commit gate passed with Python 3.13 and PRE_COMMIT_HOME=/tmp/codex-precommit-trendmicroapexone-psaas30959-v224.
- Package dependency, static, Semgrep, documentation, NOTICE, and release-note hooks passed.

## Breaking change

Existing assets using self-signed or private-CA certificates must explicitly disable Verify server certificate or install the issuing CA.

Written by Codex.